### PR TITLE
Replace #color_enabled= with #color= since it's removed in RSpec 3.0.0

### DIFF
--- a/bin/kelbim
+++ b/bin/kelbim
@@ -162,7 +162,7 @@ begin
     end
 
     RSpec.configure do |config|
-      config.color_enabled = options[:color]
+      config.color = options[:color]
       config.output_stream = $stdout # formatterをセットする前に設定…
       config.formatter = Kelbim::RSpecFormatter
     end


### PR DESCRIPTION
When I use `kelbim -t` with RSpec 3.0+ environment, I receive an error like
```
[ERROR] undefined method `color_enabled=' for #<RSpec::Core::Configuration:0x007f9c6d6c3660>
Did you mean?  color_enabled?
```
It's caused by deprecation of `#color_enabled=` in RSpec 3.0.0, so I just replaced it with `#color=`.
> Breaking Changes for 3.0.0:
> * Remove `color_enabled` as an alias of `color`. (Jon Rowe)

It may be a good idea to specify RSpec version requirement (`">= 3.0.0"`) in gemspec but I didn't include that because it's not mandatory.