### PR TITLE
ReferencePolicy

### DIFF
--- a/lib/kelbim/wrapper/policy.rb
+++ b/lib/kelbim/wrapper/policy.rb
@@ -26,6 +26,10 @@ module Kelbim
                     @policy.name == dsl_name_or_attrs
                   else
                     aws_attrs = PolicyTypes.expand(@policy.type, @policy.attributes)
+                    aws_attrs.each do |name, value|
+                      value = value[0] if value.length < 2
+                      aws_attrs[name] = value
+                    end
                     aws_attrs.sort == dsl_name_or_attrs.sort
                   end
                 end


### PR DESCRIPTION
@winebarrel 
Current kelbim is not aware of AWS-provided SSL negotiation policy set like `ELBSecurityPolicy-2016-08`.

We have been forced to write long `ssl_negotiation`
```ruby
listener [:https, 443] => [:http, 80] do
   ssl_negotiation [
    'Protocol-TLSv1',
    'Protocol-TLSv1.1',
    'Protocol-TLSv1.2',
    'Server-Defined-Cipher-Order',
    'ECDHE-ECDSA-AES128-GCM-SHA256',
    'ECDHE-RSA-AES128-GCM-SHA256',
    ...
    'AES256-SHA',
  ]
end
```

This patch enables kelbim to utilise such policy sets:

```ruby
ssl_negotiation reference: %(ELBSecurityPolicy-2016-08)
```
or
```ruby
ssl_negotiation reference: 'ELBSecurityPolicy-2016-08'
```

Note that this patch breaks backward compatibility; It makes a bit large diff if you give "old" style `ssl_negotiation` for ELB with an AWS-provided policy set like
```ruby
ssl_negotiation ['Protocol-TLSv1', ...]
```