### PR TITLE
Bugfix: aws_attrs may be an array

### DIFF
--- a/lib/kelbim/wrapper/policy.rb
+++ b/lib/kelbim/wrapper/policy.rb
@@ -26,9 +26,11 @@ module Kelbim
                     @policy.name == dsl_name_or_attrs
                   else
                     aws_attrs = PolicyTypes.expand(@policy.type, @policy.attributes)
-                    aws_attrs.each do |name, value|
-                      value = value[0] if value.length < 2
-                      aws_attrs[name] = value
+                    if aws_attrs.is_a?(Hash)
+                      aws_attrs.each do |name, value|
+                        value = value[0] if value.length < 2
+                        aws_attrs[name] = value
+                      end
                     end
                     aws_attrs.sort == dsl_name_or_attrs.sort
                   end


### PR DESCRIPTION
@winebarrel 
It's a very shameful mistake that `aws_attrs` can be an array.
Obviously we need to extract hash only when it's actually a hash.